### PR TITLE
check err and settings in scheduler add

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -136,6 +136,12 @@ var Utils = {
 			}
 
 			Backend.getPollSettings(pollid, function(err, settings) {
+				if (err) {
+					return console.log(err.stack);
+				}
+				if (!settings) {
+					return console.log('Poll ID - ' + pollid + ' has no settings!');
+				}
 				var now = Date.now(),
 					end = parseInt(settings.end, 10);
 				if (end < now) {


### PR DESCRIPTION
was crashing for a poll that apparently had no settings.
TypeError: Cannot read property 'end' of null
    at /var/www/nodebb/node_modules/nodebb-plugin-poll/lib/utils.js:140:29
    at /var/www/nodebb/node_modules/mongodb/lib/mongodb/collection/query.js:159:5
    at /var/www/nodebb/node_modules/mongodb/lib/mongodb/cursor.js:758:35
    at Cursor.close (/var/www/nodebb/node_modules/mongodb/lib/mongodb/cursor.js:983:5)
    at Cursor.nextObject (/var/www/nodebb/node_modules/mongodb/lib/mongodb/cursor.js:758:17)
    at commandHandler (/var/www/nodebb/node_modules/mongodb/lib/mongodb/cursor.js:727:14)
    at /var/www/nodebb/node_modules/mongodb/lib/mongodb/db.js:1847:9
    at Server.Base._callHandler (/var/www/nodebb/node_modules/mongodb/lib/mongodb/connection/base.js:445:41)
    at /var/www/nodebb/node_modules/mongodb/lib/mongodb/connection/server.js:478:18
    at MongoReply.parseBody (/var/www/nodebb/node_modules/mongodb/lib/mongodb/responses/mongo_reply.js:68:5)
