### PR TITLE
don't require composer on cold load

### DIFF
--- a/public/js/poll/creator.js
+++ b/public/js/poll/creator.js
@@ -8,9 +8,11 @@
 	var composer;
 
 	function init() {
-		require(['composer'], function(c) {
-			composer = c;
-			c.addButton('fa fa-bar-chart-o', Creator.show);
+		$(window).on('action:composer.enhanced', function() {
+			require(['composer'], function(c) {
+				composer = c;
+				c.addButton('fa fa-bar-chart-o', Creator.show);
+			});
 		});
 	}
 


### PR DESCRIPTION
it will be required when the composer is loaded
without this every user loads the entire composer js on page load