### PR TITLE
Add voteCounts override property for remote AP polls

### DIFF
--- a/lib/poll.js
+++ b/lib/poll.js
@@ -202,7 +202,16 @@ Poll.getInfo = async function (pollId, withVotes = false) {
 	if (!poll) {
 		return null;
 	}
-	poll.voteCount = parseInt(voteCount, 10) || 0;
+
+	// Check for vote counts override (e.g., from remote AP Question)
+	const override = await Poll.getVoteCountsOverride(pollId);
+	if (override) {
+		poll.voteCount = override.total || 0;
+		poll.uniqueVoters = override.uniqueVoters || null;
+	} else {
+		poll.voteCount = parseInt(voteCount, 10) || 0;
+	}
+
 	const end = parseInt(poll.end, 10);
 	poll.ended = end > 0 && Date.now() > end;
 	poll.options = await loadOptions(pollId, poll.options, withVotes);
@@ -221,6 +230,18 @@ Poll.getPollOptionIds = async function (pollId) {
 
 async function loadOptions(pollId, optionsJson, withVotes = false) {
 	const options = tryParseOptions(optionsJson);
+
+	// Check for vote counts override (e.g., from remote AP Question)
+	const override = await Poll.getVoteCountsOverride(pollId);
+	if (override) {
+		options.forEach((option, index) => {
+			if (option) {
+				const ov = override.options?.find(o => String(o.id) === String(option.id));
+				option.voteCount = ov?.voteCount || 0;
+			}
+		});
+		return options;
+	}
 
 	const votes = await db.getSortedSetsMembers(options.map(o => `poll:${pollId}:options:${o.id}:votes`));
 
@@ -246,18 +267,28 @@ function tryParseOptions(optionsJson) {
 }
 
 Poll.getOption = async function (pollId, option, withVotes = false) {
-	const [optionsJson, votes, voteCount] = await Promise.all([
-		db.getObjectField(`poll:${pollId}`, 'options'),
-		withVotes ?
-			db.getSortedSetRange(`poll:${pollId}:options:${option}:votes`, 0, -1) :
-			null,
-		Poll.getOptionVoteCount(pollId, option),
-	]);
+	const optionsJson = await db.getObjectField(`poll:${pollId}`, 'options');
 	const options = tryParseOptions(optionsJson);
 	const optionData = options.find(opt => String(opt.id) === String(option));
 	if (!optionData) {
 		return null;
 	}
+
+	// Check for vote counts override (e.g., from remote AP Question)
+	const override = await Poll.getVoteCountsOverride(pollId);
+	if (override) {
+		const ov = override.options?.find(o => String(o.id) === String(option));
+		optionData.voteCount = ov?.voteCount || 0;
+		// No voter identity data available for override polls
+		return optionData;
+	}
+
+	const [votes, voteCount] = await Promise.all([
+		withVotes ?
+			db.getSortedSetRange(`poll:${pollId}:options:${option}:votes`, 0, -1) :
+			null,
+		Poll.getOptionVoteCount(pollId, option),
+	]);
 
 	if (votes) {
 		optionData.votes = votes;
@@ -267,10 +298,20 @@ Poll.getOption = async function (pollId, option, withVotes = false) {
 };
 
 Poll.getVotersCount = async function (pollId) {
+	// Check for vote counts override (e.g., from remote AP Question)
+	const override = await Poll.getVoteCountsOverride(pollId);
+	if (override) {
+		return override.uniqueVoters || null;
+	}
 	return await db.sortedSetCard(`poll:${pollId}:voters`);
 };
 
 Poll.getVoteCount = async function (pollId) {
+	// Check for vote counts override (e.g., from remote AP Question)
+	const override = await Poll.getVoteCountsOverride(pollId);
+	if (override) {
+		return override.total || 0;
+	}
 	const optionIds = await Poll.getPollOptionIds(pollId);
 	return await db.sortedSetsCardSum(
 		optionIds.map(option => `poll:${pollId}:options:${option}:votes`)
@@ -278,7 +319,34 @@ Poll.getVoteCount = async function (pollId) {
 };
 
 Poll.getOptionVoteCount = async function (pollId, option) {
+	// Check for vote counts override (e.g., from remote AP Question)
+	const override = await Poll.getVoteCountsOverride(pollId);
+	if (override) {
+		const ov = override.options?.find(o => String(o.id) === String(option));
+		return ov?.voteCount || 0;
+	}
 	return await db.sortedSetCard(`poll:${pollId}:options:${option}:votes`);
+};
+
+/**
+ * Returns the vote counts override object if set on the poll, otherwise null.
+ * The override is stored as JSON in the `voteCounts` field of the poll hash.
+ * Expected shape: { total: number, uniqueVoters: number, options: [{ id, voteCount }] }
+ */
+Poll.getVoteCountsOverride = async function (pollId) {
+	const raw = await db.getObjectField(`poll:${pollId}`, 'voteCounts');
+	if (!raw) {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse(raw);
+		if (typeof parsed.total === 'number' && Array.isArray(parsed.options)) {
+			return parsed;
+		}
+		return null;
+	} catch {
+		return null;
+	}
 };
 
 Poll.hasOption = async function (pollId, option) {


### PR DESCRIPTION
I am implementing ActivityPub integration into the poll plugin. While core can remix the incoming activities into a plugin-compatible `polls` property, there is one difference that requires a plugin change:

* The poll plugin tracks votes based on uids (one uid, one vote).
* ActivityPub Polls do not share voter identification data, only aggregate vote counts (e.g. Option A: 5 votes, Option B: 10 votes)

One solution is to introduce a `voteCounts` property in the poll hash itself which is a JSON-serialized aggregate of vote counts. This would _only apply to remote polls created via AP_. Local polls would not be affected.

<details>
<summary>
AI summary
</summary>

Introduce a read-only voteCounts property on poll objects that allows
polls created from remote ActivityPub Question activities to display
correct vote counts without requiring individual voter identity data.

When voteCounts is present as a JSON field on poll:{pollId}, all vote
counting methods short-circuit and use the stored values instead of
reading from vote sorted sets. This enables aggregate-only vote data
from remote servers to be displayed correctly.

The override shape: { total, uniqueVoters, options: [{ id, voteCount }] }

Assisted-by: unsloth/Qwen3.6-35B-A3B-GGUF


### Summary of changes                                                                                                                     
                                                                                                                                            
 New method: Poll.getVoteCountsOverride(pollId) — reads the voteCounts field from the poll hash, validates the shape ({ total, options: [{  
 id, voteCount }] }), and returns the parsed object or null.                                                                                
                                                                                                                                            
 Five callers short-circuit when an override exists:                                                                                        
                                                                                                                                            
 | Method | Override behavior |
|-|-|
| Poll.getInfo | Uses override.total for voteCount; sets override.uniqueVoters |
| loadOptions | Skips DB sorted set reads; populates option.voteCount from override.options |
| Poll.getOption | Skips DB reads entirely; returns optionData with override count |
| Poll.getVoteCount | Returns override.total |
| Poll.getOptionVoteCount | Looks up the option in override.options by ID |
| Poll.getVotersCount | Returns override.uniqueVoters |

 ### How to set the override (from your AP code)                      

 ```js                             
   await db.setObjectField(`poll:${pollId}`, 'voteCounts', JSON.stringify({                                                                 
       total: 42,                  
       uniqueVoters: 38,           
       options: [                  
           { id: "opt1", voteCount: 25 },                             
           { id: "opt2", voteCount: 17 },                             
       ],                          
   }));                            
 ```                 
</details>